### PR TITLE
Fix the og:url so links can be shared by Plinky

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta property="og:title" content="Tim Walz Facts">
     <meta property="og:description" content="Learn about Tim Walz">
     <meta property="og:image" content="walz01.png">
-    <meta property="og:url" content="https://example.com/meme-generator">
+    <meta property="og:url" content="https://dfeldman.github.io/walz/">
     <meta name="twitter:card" content="summary_large_image">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <style>


### PR DESCRIPTION
Fix the og:url so links can be shared by Plinky

I tried sharing this url using [Plinky](https://www.plinky.app/) and the operation failed. The maintainer indicated it was because the og:url value was not set correctly. This PR changes the value from an `example.com` domain to the current site url.